### PR TITLE
pine64-common: add v4l-utils package

### DIFF
--- a/pine64-common.yaml
+++ b/pine64-common.yaml
@@ -80,3 +80,9 @@ actions:
   - action: run
     chroot: true
     script: scripts/try-depmod-installed.sh
+
+  - action: run
+    chroot: true
+    description: Install v4l-utils to control camera pipeline
+    label: apt
+    script: scripts/apt-install.sh v4l-utils


### PR DESCRIPTION
This package contains media-ctl program used to control camera pipeline.

See https://gitlab.com/ubports/community-ports/pinephone/-/merge_requests/5